### PR TITLE
Update escrow to feature metadata, recipient can be set after creation

### DIFF
--- a/contracts/cw20-escrow/src/contract.rs
+++ b/contracts/cw20-escrow/src/contract.rs
@@ -478,6 +478,7 @@ mod tests {
     fn set_recipient_after_creation() {
         let mut deps = mock_dependencies();
 
+
         // instantiate an empty contract
         let instantiate_msg = InstantiateMsg {};
         let info = mock_info(&String::from("anyone"), &[]);

--- a/contracts/cw20-escrow/src/contract.rs
+++ b/contracts/cw20-escrow/src/contract.rs
@@ -41,6 +41,9 @@ pub fn execute(
         ExecuteMsg::Create(msg) => {
             execute_create(deps, msg, Balance::from(info.funds), &info.sender)
         }
+        ExecuteMsg::SetRecipient { id, recipient } => {
+            execute_set_recipient(deps, env, info, id, recipient)
+        }
         ExecuteMsg::Approve { id } => execute_approve(deps, env, info, id),
         ExecuteMsg::TopUp { id } => execute_top_up(deps, id, Balance::from(info.funds)),
         ExecuteMsg::Refund { id } => execute_refund(deps, env, info, id),
@@ -95,11 +98,18 @@ pub fn execute_create(
             }
         }
     };
+    let recipient = if msg.recipient.is_some() {
+        Some(deps.api.addr_validate(&msg.recipient.unwrap())?)
+    } else {
+        None
+    };
 
     let escrow = Escrow {
         arbiter: deps.api.addr_validate(&msg.arbiter)?,
-        recipient: deps.api.addr_validate(&msg.recipient)?,
+        recipient,
         source: sender.clone(),
+        title: msg.title,
+        description: msg.description,
         end_height: msg.end_height,
         end_time: msg.end_time,
         balance: escrow_balance,
@@ -114,6 +124,28 @@ pub fn execute_create(
 
     let res = Response::new().add_attributes(vec![("action", "create"), ("id", msg.id.as_str())]);
     Ok(res)
+}
+
+pub fn execute_set_recipient(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    id: String,
+    recipient: String,
+) -> Result<Response, ContractError> {
+    let mut escrow = ESCROWS.load(deps.storage, &id)?;
+    if info.sender != escrow.arbiter {
+        return Err(ContractError::Unauthorized {});
+    }
+    let recipient = deps.api.addr_validate(recipient.as_str())?;
+    escrow.recipient = Some(recipient.clone());
+
+    ESCROWS.save(deps.storage, &id, &escrow)?;
+    Ok(Response::new().add_attributes(vec![
+        ("action", "set_recipient"),
+        ("id", id.as_str()),
+        ("recipient", recipient.as_str()),
+    ]))
 }
 
 pub fn execute_top_up(
@@ -157,16 +189,20 @@ pub fn execute_approve(
     } else if escrow.is_expired(&env) {
         Err(ContractError::Expired {})
     } else {
+        if escrow.recipient.is_none() {
+            return Err(ContractError::RecipientNotSet {});
+        }
         // we delete the escrow
         ESCROWS.remove(deps.storage, &id);
 
         // send all tokens out
-        let messages: Vec<SubMsg> = send_tokens(&escrow.recipient, &escrow.balance)?;
+        let messages: Vec<SubMsg> =
+            send_tokens(&escrow.recipient.clone().unwrap(), &escrow.balance)?;
 
         Ok(Response::new()
             .add_attribute("action", "approve")
             .add_attribute("id", id)
-            .add_attribute("to", escrow.recipient)
+            .add_attribute("to", escrow.recipient.unwrap_or_else(|| Addr::unchecked("")))
             .add_submessages(messages))
     }
 }
@@ -257,11 +293,18 @@ fn query_details(deps: Deps, id: String) -> StdResult<DetailsResponse> {
         })
         .collect();
 
+    let recipient = if escrow.recipient.is_some() {
+        Some(escrow.recipient.unwrap().into_string())
+    } else {
+        None
+    };
     let details = DetailsResponse {
         id,
         arbiter: escrow.arbiter.into(),
-        recipient: escrow.recipient.into(),
+        recipient,
         source: escrow.source.into(),
+        title: escrow.title,
+        description: escrow.description,
         end_height: escrow.end_height,
         end_time: escrow.end_time,
         native_balance,
@@ -280,7 +323,7 @@ fn query_list(deps: Deps) -> StdResult<ListResponse> {
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coin, coins, CosmosMsg, StdError, Uint128};
+    use cosmwasm_std::{attr, coin, coins, CosmosMsg, StdError, Uint128};
 
     use crate::msg::ExecuteMsg::TopUp;
 
@@ -300,10 +343,12 @@ mod tests {
         let create = CreateMsg {
             id: "foobar".to_string(),
             arbiter: String::from("arbitrate"),
-            recipient: String::from("recd"),
+            recipient: Some(String::from("recd")),
+            title: "some_title".to_string(),
             end_time: None,
             end_height: Some(123456),
             cw20_whitelist: None,
+            description: "some_description".to_string(),
         };
         let sender = String::from("source");
         let balance = coins(100, "tokens");
@@ -320,8 +365,10 @@ mod tests {
             DetailsResponse {
                 id: "foobar".to_string(),
                 arbiter: String::from("arbitrate"),
-                recipient: String::from("recd"),
+                recipient: Some(String::from("recd")),
                 source: String::from("source"),
+                title: "some_title".to_string(),
+                description: "some_description".to_string(),
                 end_height: Some(123456),
                 end_time: None,
                 native_balance: balance.clone(),
@@ -339,7 +386,7 @@ mod tests {
         assert_eq!(
             res.messages[0],
             SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
-                to_address: create.recipient,
+                to_address: create.recipient.unwrap(),
                 amount: balance,
             }))
         );
@@ -365,10 +412,12 @@ mod tests {
         let create = CreateMsg {
             id: "foobar".to_string(),
             arbiter: String::from("arbitrate"),
-            recipient: String::from("recd"),
+            recipient: Some(String::from("recd")),
+            title: "some_title".to_string(),
             end_time: None,
             end_height: None,
             cw20_whitelist: Some(vec![String::from("other-token")]),
+            description: "some_description".to_string(),
         };
         let receive = Cw20ReceiveMsg {
             sender: String::from("source"),
@@ -389,8 +438,10 @@ mod tests {
             DetailsResponse {
                 id: "foobar".to_string(),
                 arbiter: String::from("arbitrate"),
-                recipient: String::from("recd"),
+                recipient: Some(String::from("recd")),
                 source: String::from("source"),
+                title: "some_title".to_string(),
+                description: "some_description".to_string(),
                 end_height: None,
                 end_time: None,
                 native_balance: vec![],
@@ -409,7 +460,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
         assert_eq!(("action", "approve"), res.attributes[0]);
         let send_msg = Cw20ExecuteMsg::Transfer {
-            recipient: create.recipient,
+            recipient: create.recipient.unwrap(),
             amount: receive.amount,
         };
         assert_eq!(
@@ -426,6 +477,107 @@ mod tests {
         let info = mock_info(&create.arbiter, &[]);
         let err = execute(deps.as_mut(), mock_env(), info, ExecuteMsg::Approve { id }).unwrap_err();
         assert!(matches!(err, ContractError::Std(StdError::NotFound { .. })));
+    }
+
+    #[test]
+    fn set_recipient_after_creation() {
+        let mut deps = mock_dependencies();
+
+        // instantiate an empty contract
+        let instantiate_msg = InstantiateMsg {};
+        let info = mock_info(&String::from("anyone"), &[]);
+        let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
+        assert_eq!(0, res.messages.len());
+
+        // create an escrow
+        let create = CreateMsg {
+            id: "foobar".to_string(),
+            arbiter: String::from("arbitrate"),
+            recipient: None,
+            title: "some_title".to_string(),
+            end_time: None,
+            end_height: Some(123456),
+            cw20_whitelist: None,
+            description: "some_description".to_string(),
+        };
+        let sender = String::from("source");
+        let balance = coins(100, "tokens");
+        let info = mock_info(&sender, &balance);
+        let msg = ExecuteMsg::Create(create.clone());
+        let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+        assert_eq!(("action", "create"), res.attributes[0]);
+
+        // ensure the details is what we expect
+        let details = query_details(deps.as_ref(), "foobar".to_string()).unwrap();
+        assert_eq!(
+            details,
+            DetailsResponse {
+                id: "foobar".to_string(),
+                arbiter: String::from("arbitrate"),
+                recipient: None,
+                source: String::from("source"),
+                title: "some_title".to_string(),
+                description: "some_description".to_string(),
+                end_height: Some(123456),
+                end_time: None,
+                native_balance: balance.clone(),
+                cw20_balance: vec![],
+                cw20_whitelist: vec![],
+            }
+        );
+
+        // approve it, should fail as we have not set recipient
+        let id = create.id.clone();
+        let info = mock_info(&create.arbiter, &[]);
+        let res = execute(deps.as_mut(), mock_env(), info, ExecuteMsg::Approve { id });
+        match res {
+            Err(ContractError::RecipientNotSet {}) => {}
+            _ => panic!("Expect recipient not set error"),
+        }
+
+        // test setting recipient not arbiter
+        let msg = ExecuteMsg::SetRecipient {
+            id: create.id.clone(),
+            recipient: "recp".to_string(),
+        };
+        let info = mock_info("someoneelse", &[]);
+        let res = execute(deps.as_mut(), mock_env(), info, msg.clone());
+        match res {
+            Err(ContractError::Unauthorized {}) => {}
+            _ => panic!("Expect unauthorized error"),
+        }
+
+        // test setting recipient valid
+        let msg = ExecuteMsg::SetRecipient {
+            id: create.id.clone(),
+            recipient: "recp".to_string(),
+        };
+        let info = mock_info(&create.arbiter, &[]);
+        let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(res.messages.len(), 0);
+        assert_eq!(
+            res.attributes,
+            vec![
+                attr("action", "set_recipient"),
+                attr("id", create.id.as_str()),
+                attr("recipient", "recp")
+            ]
+        );
+
+        // approve it, should now work with recp
+        let id = create.id.clone();
+        let info = mock_info(&create.arbiter, &[]);
+        let res = execute(deps.as_mut(), mock_env(), info, ExecuteMsg::Approve { id }).unwrap();
+        assert_eq!(1, res.messages.len());
+        assert_eq!(("action", "approve"), res.attributes[0]);
+        assert_eq!(
+            res.messages[0],
+            SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+                to_address: "recp".to_string(),
+                amount: balance,
+            }))
+        );
     }
 
     #[test]
@@ -488,10 +640,12 @@ mod tests {
         let create = CreateMsg {
             id: "foobar".to_string(),
             arbiter: String::from("arbitrate"),
-            recipient: String::from("recd"),
+            recipient: Some(String::from("recd")),
+            title: "some_title".to_string(),
             end_time: None,
             end_height: None,
             cw20_whitelist: Some(whitelist),
+            description: "some_description".to_string(),
         };
         let sender = String::from("source");
         let balance = vec![coin(100, "fee"), coin(200, "stake")];
@@ -567,14 +721,14 @@ mod tests {
         assert_eq!(
             res.messages[0],
             SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
-                to_address: create.recipient.clone(),
+                to_address: create.recipient.clone().unwrap(),
                 amount: vec![coin(100, "fee"), coin(500, "stake"), coin(250, "random")],
             }))
         );
 
         // second one release bar cw20 token
         let send_msg = Cw20ExecuteMsg::Transfer {
-            recipient: create.recipient.clone(),
+            recipient: create.recipient.clone().unwrap(),
             amount: Uint128::new(7890),
         };
         assert_eq!(
@@ -588,7 +742,7 @@ mod tests {
 
         // third one release foo cw20 token
         let send_msg = Cw20ExecuteMsg::Transfer {
-            recipient: create.recipient,
+            recipient: create.recipient.unwrap(),
             amount: Uint128::new(888),
         };
         assert_eq!(

--- a/contracts/cw20-escrow/src/error.rs
+++ b/contracts/cw20-escrow/src/error.rs
@@ -20,4 +20,7 @@ pub enum ContractError {
 
     #[error("Escrow id already in use")]
     AlreadyInUse {},
+
+    #[error("Recipient is not set")]
+    RecipientNotSet {},
 }

--- a/contracts/cw20-escrow/src/integration_test.rs
+++ b/contracts/cw20-escrow/src/integration_test.rs
@@ -87,7 +87,9 @@ fn escrow_happy_path_cw20_tokens() {
     let create_msg = ReceiveMsg::Create(CreateMsg {
         id: id.clone(),
         arbiter: arb.to_string(),
-        recipient: ben.clone(),
+        recipient: Some(ben.clone()),
+        title: "some_title".to_string(),
+        description: "some_description".to_string(),
         end_height: None,
         end_time: None,
         cw20_whitelist: None,
@@ -126,7 +128,7 @@ fn escrow_happy_path_cw20_tokens() {
         .unwrap();
     assert_eq!(id, details.id);
     assert_eq!(arb, details.arbiter);
-    assert_eq!(ben, details.recipient);
+    assert_eq!(Some(ben.clone()), details.recipient);
     assert_eq!(
         vec![Cw20Coin {
             address: cash_addr.to_string(),

--- a/contracts/cw20-escrow/src/msg.rs
+++ b/contracts/cw20-escrow/src/msg.rs
@@ -16,6 +16,11 @@ pub enum ExecuteMsg {
     TopUp {
         id: String,
     },
+    /// Set the recipient of the given escrow
+    SetRecipient {
+        id: String,
+        recipient: String,
+    },
     /// Approve sends all tokens to the recipient.
     /// Only the arbiter can do this
     Approve {
@@ -50,7 +55,11 @@ pub struct CreateMsg {
     /// arbiter can decide to approve or refund the escrow
     pub arbiter: String,
     /// if approved, funds go to the recipient
-    pub recipient: String,
+    pub recipient: Option<String>,
+    /// Title of the escrow
+    pub title: String,
+    /// Longer description of the escrow, e.g. what conditions should be met
+    pub description: String,
     /// When end height set and block height exceeds this value, the escrow is expired.
     /// Once an escrow is expired, it can be returned to the original funder (via "refund").
     pub end_height: Option<u64>,
@@ -104,9 +113,13 @@ pub struct DetailsResponse {
     /// arbiter can decide to approve or refund the escrow
     pub arbiter: String,
     /// if approved, funds go to the recipient
-    pub recipient: String,
+    pub recipient: Option<String>,
     /// if refunded, funds go to the source
     pub source: String,
+    /// Title of the escrow
+    pub title: String,
+    /// Longer description of the escrow, e.g. what conditions should be met
+    pub description: String,
     /// When end height set and block height exceeds this value, the escrow is expired.
     /// Once an escrow is expired, it can be returned to the original funder (via "refund").
     pub end_height: Option<u64>,

--- a/contracts/cw20-escrow/src/state.rs
+++ b/contracts/cw20-escrow/src/state.rs
@@ -51,10 +51,14 @@ impl GenericBalance {
 pub struct Escrow {
     /// arbiter can decide to approve or refund the escrow
     pub arbiter: Addr,
-    /// if approved, funds go to the recipient
-    pub recipient: Addr,
+    /// if approved, funds go to the recipient, cannot approve if recipient is none
+    pub recipient: Option<Addr>,
     /// if refunded, funds go to the source
     pub source: Addr,
+    /// Title of the escrow, for example for a bug bounty "Fix issue in contract.rs"
+    pub title: String,
+    /// Description of the escrow, a more in depth description of how to meet the escrow condition
+    pub description: String,
     /// When end height set and block height exceeds this value, the escrow is expired.
     /// Once an escrow is expired, it can be returned to the original funder (via "refund").
     pub end_height: Option<u64>,
@@ -115,8 +119,10 @@ mod tests {
     fn dummy_escrow() -> Escrow {
         Escrow {
             arbiter: Addr::unchecked("arb"),
-            recipient: Addr::unchecked("recip"),
+            recipient: Some(Addr::unchecked("recip")),
             source: Addr::unchecked("source"),
+            title: "some_escrow".to_string(),
+            description: "some escrow desc".to_string(),
             end_height: None,
             end_time: None,
             balance: Default::default(),

--- a/contracts/cw20-merkle-airdrop/src/msg.rs
+++ b/contracts/cw20-merkle-airdrop/src/msg.rs
@@ -24,7 +24,7 @@ pub enum ExecuteMsg {
         merkle_root: String,
         expiration: Option<Expiration>,
         start: Option<Scheduled>,
-        total_amount: Option<Uint128>
+        total_amount: Option<Uint128>,
     },
     /// Claim does not check if contract has enough funds, owner must ensure it.
     Claim {
@@ -34,9 +34,7 @@ pub enum ExecuteMsg {
         proof: Vec<String>,
     },
     /// Burn the remaining tokens after expire time (only owner)
-    Burn {
-        stage: u8,
-    }
+    Burn { stage: u8 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -46,7 +44,7 @@ pub enum QueryMsg {
     MerkleRoot { stage: u8 },
     LatestStage {},
     IsClaimed { stage: u8, address: String },
-    TotalClaimed { stage: u8 }
+    TotalClaimed { stage: u8 },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -63,7 +61,7 @@ pub struct MerkleRootResponse {
     pub merkle_root: String,
     pub expiration: Expiration,
     pub start: Option<Scheduled>,
-    pub total_amount: Uint128
+    pub total_amount: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/cw20-merkle-airdrop/src/state.rs
+++ b/contracts/cw20-merkle-airdrop/src/state.rs
@@ -1,9 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{
-    Addr, Uint128
-};
+use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
 use cw_utils::{Expiration, Scheduled};
 


### PR DESCRIPTION
After discussions with @JakeHartnell and @orkunkl we decided to expand functionality for escrow, this new functionality is as follows:

- Recipient is now optional upon creation, this allows Escrows to be used as bounties e.g. for bug bounties etc.
- Recipient can be set by the arbiter using the new SetRecipient message
- Escrows now feature additional meta data, including a title and description. E.g. for a bounty the description may include steps needed to be valid for said bounty.

Tests are added/updated accordingly.

Feedback as always is welcome